### PR TITLE
Rollback AU915 to FSB2 add DualPlan and AS923

### DIFF
--- a/main/ttn.cpp
+++ b/main/ttn.cpp
@@ -325,14 +325,23 @@ void ttn_join(void) {
   // other regions, this will need to be changed.
   LMIC_selectSubBand(1);
 
+#elif defined(CFG_au915) && defined(CFG_au915_fsb6)
+
+  // AU915 FSB6
+  // CH 40-47 (923.2 - 924.6 MHz)
+  // Helium DualPlan was live in Australia 2022-11-17 to 2023-04-18
+  // DualPlan allowed AU915 devices to co-exist with AS923 by taking advantage
+  // of some AU915 FSB6 frequencies overlapping AS923 frequencies.
+  // If a device joined on the first two channels of FSB6, it was treated as
+  // an AS923 device. On the last 6 channels, an AU915 device.
+  LMIC_selectSubBand(5);
+
 #elif defined(CFG_au915)
 
-  // set sub band for AU915
-  // before 2022-11-17 Helium was using FSB2 CH 8-15 (916.8 - 918.2 MHz uplink)
+  // AU915 FSB2
+  // CH 8-15 (916.8 - 918.2 MHz uplink)
   // https://github.com/TheThingsNetwork/gateway-conf/blob/master/AU-global_conf.json
-  // LMIC_selectSubBand(1);
-  // after 2022-11-17 Helium switched to DualPlan using FSB6 CH 40-47 (923.2 - 924.6 MHz uplink)
-  LMIC_selectSubBand(5);
+  LMIC_selectSubBand(1);
 
 #endif
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,8 @@ build_flags = -Wall
 	-D CFG_us915=1
 ;	-D CFG_eu868=1
 ;	-D CFG_au915=1
+;	-D CFG_au915_fsb6=1
+;	-D CFG_as923=1
 	-D CFG_sx1276_radio=1
 	-D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
 	-D ARDUINO_TTGO_LoRa32_V1
@@ -40,5 +42,5 @@ monitor_speed = 115200
 
 [env:debug]
 debug_build_flags = 
-    -D DEBUG
+	-D DEBUG
 	-D LMIC_DEBUG_LEVEL=3


### PR DESCRIPTION
In Australia on 2022-11-17 Helium switched all gateways from AU915 to AS923-1 to enable DualPlan.
The switch required changing the existing AU915 config to pin FSB6 channels instead of FSB2.
This was added in PR: https://github.com/Max-Plastix/tbeam-helium-mapper/pull/7

Helium's DualPlan was to allow AU915 and AS923 devices to co-exist and was basically just shuffling AU915 pinned sub band from FSB2 to FSB6 so it overlaps with AS923, then adding LNS tricks to interpret joins on the first 2 ch (40-41) as AS923 device and joins on the last 6 ch (42-47) as AU915 devices.

As of 2023-04-17, Australia has now rolled back all gateways from AS923-1 to AU915 (FSB2).
To support any hotspots remaining on AS923-1, I've added an new interim config option `CFG_au915_fsb6`, which continues to pin FSB6 channels, while still inheriting the base `CFG_au915` LMIC config.

Once the dust has settled and all AU915 devices are back on FSB2, we can remove the `CFG_au915_fsb6` option from main/ttn.cpp.

In platformio.ini, uncomment the build flag options to select your preferred config.

```
# AU915 FSB2 (ch 8-15)
;	-D CFG_us915=1
	-D CFG_au915=1
;	-D CFG_au915_fsb6=1
;	-D CFG_as923=1
```

```
# Legacy AU915 FSB6 DualPlan (ch 42-47)
;	-D CFG_us915=1
	-D CFG_au915=1
	-D CFG_au915_fsb6=1
;	-D CFG_as923=1
```

```
# AS923 (ch 0-1)
;	-D CFG_us915=1
;	-D CFG_au915=1
;	-D CFG_au915_fsb6=1
	-D CFG_as923=1
```

Tested on TTGO T-Beam V1.1 in Australia 👍 