### PR TITLE
Payload with 7 instead of 11 bytes.

### DIFF
--- a/console-decoders/unified_decoder.js
+++ b/console-decoders/unified_decoder.js
@@ -32,6 +32,13 @@ function Decoder(bytes, port) {
       decoded.sats = bytes[10];
       decoded.accuracy = 2.5; // Bogus Accuracy required by Cargo/Mapper integration
       break;
+    case 3: // Mapper short! (Cargo and Heatmap too)
+      decoded.latitude = latitude;
+      decoded.longitude = longitude;
+      decoded.altitude = (bytes[6] >> 3)*150;
+      decoded.sats = (bytes[6] & 0x7)+3;
+      decoded.accuracy = 2.5; // Bogus Accuracy required by Cargo/Mapper integration
+      break;
     case 5: // System status
       decoded.last_latitude = latitude;
       decoded.last_longitude = longitude;
@@ -60,4 +67,11 @@ function Decoder(bytes, port) {
   }
 
   return decoded;
+}
+
+// Wrapper for ChirpStack V4:
+function decodeUplink(input) {
+  return { 
+      data: Decoder(input.bytes, input.fPort)
+  };   
 }

--- a/main/configuration.h
+++ b/main/configuration.h
@@ -107,6 +107,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEADZONE_RADIUS_M 500  // meters
 #endif
 
+// Uplink format, defaults into a shorter payload. 7 bytes instead of 11. The altitude is in blocks of 150m
+// and the sattelite count is combined into a single byte. The decoder takes care of this.
+#define UPLINK_SHORT 
+
 // There are some extra non-Mapper Uplink messages we can send, but there's no good way to avoid sending these
 // to all Integrations from the Decoder.  This causes (normal) Error messages on the Console because Mapper will throw
 // them out for having no coordinates.  It doesn't hurt anything, as they are correctly filtered by the Decoder, but if

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,8 +18,8 @@ framework = arduino
 build_flags = -Wall
 	-Wextra
 	-Wno-missing-field-initializers -O3
-	-D CFG_us915=1
-;	-D CFG_eu868=1
+;	-D CFG_us915=1
+	-D CFG_eu868=1
 ;	-D CFG_au915=1
 	-D CFG_sx1276_radio=1
 	-D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
@@ -27,7 +27,7 @@ build_flags = -Wall
 
 lib_deps = 
 	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.3.0
+	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.4.1
 	lewisxhe/AXP202X_Library@^1.1.3
 	mikalhart/TinyGPSPlus@^1.0.3
 


### PR DESCRIPTION
Hello,
this is a alternative payload with minimal information. As Lora is airtime limited and the Helium network charges per byte, it enables operating a mapper device at a lower cost.

The payload is 7 bytes. 6 bytes for lat/long is unchanged. Then only one byte for the altitude and satellite counts together. 
This byte is 5 bits for altitude, counting from 0 to 31 with a step size of 150m. That gives a possible altitude to report from 0m up to 4650. Sufficient for most applications. The remaining 3 bit are for the satellite count, as 3 is the minimum for a 3D lock the value range goes from 3 to 10.

To distinguish between the formats i used the FPort byte, the decoder uses this to decide how to read the payload.

I am running this on a T-Beam 1.0 with Helium-IoT as LNS. Mapping works identically as with the original payload.

Greetings!